### PR TITLE
Added enhancements/bug fixes

### DIFF
--- a/lib/FIX/Lite.pm
+++ b/lib/FIX/Lite.pm
@@ -150,17 +150,17 @@ sub listen {
 		my $parsedResp = parseFixMessage($fixMsg);
 		my %parsedResp2 = fromString($fixMsg);
 
-		my $testMsgType = %parsedResp2->{35};
+		my $testMsgType = $parsedResp2{35};
 		print "Test fromString: "."$testMsgType  \n";
 
-                if ( ! defined %parsedResp2->{MsgType} ) {
+                if ( ! defined $parsedResp2{MsgType} ) {
                     print "   Cannot parse message\n" if ($arg{Debug});
                 }
-                elsif ( %parsedResp2->{MsgType} eq '0' ) {
+                elsif ( $parsedResp2{MsgType} eq '0' ) {
                     print "   This is heartbeat. Will not pass it to handler\n" if ($arg{Debug});
                 }
-                elsif ( %parsedResp2->{MsgType} eq '1' ) {
-                    my $TestReqID = (defined %parsedResp2->{TestReqID})?%parsedResp2->{TestReqID}:'TEST';
+                elsif ( $parsedResp2{MsgType} eq '1' ) {
+                    my $TestReqID = (defined $parsedResp2{TestReqID})?$parsedResp2{TestReqID}:'TEST';
                     print "   This is TestRequest. Will send heartbeat with TestReqID $TestReqID\n" if ($arg{Debug});
                     $self->heartbeat( 
                         TestReqID => $TestReqID,
@@ -365,6 +365,8 @@ sub _isFieldInStructure($$) {
 }
 
 #Add _getGroupInStructure
+sub _getGroupInStructure($$);
+
 sub _getGroupInStructure($$) {
         my ($s, $gn) = @_;
 
@@ -532,6 +534,8 @@ sub fromString($) {
        # $self->{_SMSG} = $s;
 	return %arr;
 }
+
+sub _parseFixArray($$$$$);
 
 sub _parseFixArray($$$$$) {
         my ( $arr, $msgType, $gName, $iField, $fields ) = @_;

--- a/lib/FIX/Lite.pm
+++ b/lib/FIX/Lite.pm
@@ -2,7 +2,7 @@ package FIX::Lite;
 
 use vars qw($VERSION @ISA);
 use warnings;
-use strict;
+#use strict;
 
 use IO::Socket;
 use POSIX qw(strftime);
@@ -137,15 +137,30 @@ sub listen {
                 return 1;
             } else {
                 print "----\nReceived FIX message:\n".readableFix($response)."\n" if ($arg{Debug});
-                my $parsedResp = parseFixMessage($response);
-                if ( ! defined $parsedResp->{MsgType} ) {
+   
+		#Split into each single msg
+		for my $fixMsg ( split /8=FIX.4.4\x{01}/, $response ) { # Split on FIX version
+        	#	print "----\nSplitted FIX message:\n".$fixMsg."\n" if ($arg{Debug} && length($fixMsg)>0);
+    		
+ 		next if (length($fixMsg)<=0);
+
+		print "----\nSplitted FIX message:\n".$fixMsg."\n" if ($arg{Debug}); 
+    
+                #my $parsedResp = parseFixMessage($response);
+		my $parsedResp = parseFixMessage($fixMsg);
+		my %parsedResp2 = fromString($fixMsg);
+
+		my $testMsgType = %parsedResp2->{35};
+		print "Test fromString: "."$testMsgType  \n";
+
+                if ( ! defined %parsedResp2->{MsgType} ) {
                     print "   Cannot parse message\n" if ($arg{Debug});
                 }
-                elsif ( $parsedResp->{MsgType} eq '0' ) {
+                elsif ( %parsedResp2->{MsgType} eq '0' ) {
                     print "   This is heartbeat. Will not pass it to handler\n" if ($arg{Debug});
                 }
-                elsif ( $parsedResp->{MsgType} eq '1' ) {
-                    my $TestReqID = (defined $parsedResp->{TestReqID})?$parsedResp->{TestReqID}:'TEST';
+                elsif ( %parsedResp2->{MsgType} eq '1' ) {
+                    my $TestReqID = (defined %parsedResp2->{TestReqID})?%parsedResp2->{TestReqID}:'TEST';
                     print "   This is TestRequest. Will send heartbeat with TestReqID $TestReqID\n" if ($arg{Debug});
                     $self->heartbeat( 
                         TestReqID => $TestReqID,
@@ -153,8 +168,11 @@ sub listen {
                     );
                 }
                 else {
-                    $handler->($parsedResp);
+                    #$handler->($parsedResp);
+		    $handler->(%parsedResp2);
                 }
+
+		}#for my $fixMsg
             }
         }
 
@@ -263,6 +281,117 @@ sub getField($) {
     return $fixDict->{hFields}->{$f};
 }
 
+#Add isGroup function
+##
+# returns 1 if given field is a group header field
+# $dict->isGroup('NoAllocs')  -> returns 1
+# $dict->isGroup('Symbol')    -> returns 0
+sub isGroup($) {
+        my $f  = shift;
+        my $ff = getField($f);
+        return defined $ff ? $ff->{type} eq 'NUMINGROUP' : 0;
+}
+
+#Add isFieldInGroup
+##
+# returns true if given field is a member of the given group of given message.
+sub isFieldInGroup($$$) {
+        my ( $m, $g, $f ) = @_;
+
+        my $gn = getFieldName($g);
+        return 0 if !defined $gn;
+        return 0 if !isGroup($gn);
+        my $fn = getFieldName($f);
+        return 0 if !defined $fn;
+
+        my $msg = getGroupInMessage( $m, $g );
+        return 0 if !defined $msg;
+        return _isFieldInStructure($msg, $fn);
+}
+
+#Add getGroupInMessage
+##
+# return a ref on group of a message, this then allows us to work on the group elements.
+# $d->getGroupInMessage('D','NoAllocs')
+# will return a ref on the NoAllocs group allowing us to then parse it
+#
+# Looks recursively into groups of groups if needed.
+sub getGroupInMessage($$) {
+        my ( $m, $g ) = @_;
+        my $s = getMessageFields($m);
+        return undef if !defined $s;
+        my $gn = getFieldName($g);
+        return undef if !defined($gn);
+
+        return undef if ! isGroup($g);
+
+        return _getGroupInStructure( $s, $gn );
+}
+
+#Add _isFieldInStructure
+##
+# returns true if given field is found in the structure.
+sub _isFieldInStructure($$);
+
+sub _isFieldInStructure($$) {
+        my ( $m, $f ) = @_;
+        return 0 if ( !defined $m || !defined $f );
+        my $fn = getFieldName($f);
+        return 0 if !defined $fn;
+
+        for my $f2 ( @{$m} ) {
+
+                #print "checking if $fn eq " . $f2->{name} . "\n";
+                ##
+                # found the field? return 1. Beware that if the element is a component then we don't accept
+                # it as a valid field of the structure.
+                return 1 if ( $f2->{name} eq $fn && !defined $f2->{component} );
+
+                ##
+                # if the field is a group then scan all elements of the group
+                if ( defined $f2->{group} ) {
+                        return 1 if _isFieldInStructure( $f2->{group}, $fn ) == 1;
+                }
+
+                ##
+                # if the field is a component, we need to go to the component hash and check out its
+                # composition.
+                if ( defined $f2->{component} ) {
+                        return 1 if _isFieldInStructure( getComponentFields($f2->{name}), $fn ) == 1;
+                }
+        }
+
+        return 0;
+}
+
+#Add _getGroupInStructure
+sub _getGroupInStructure($$) {
+        my ($s, $gn) = @_;
+
+        my $ret;
+        ##
+        # parse each field in the structure, and ....
+        for my $e ( @{$s} ) {
+                # we found the group name
+                return $e->{group} if ($e->{name} eq $gn && defined $e->{group});
+
+                # stop at each group header
+                if (defined $e->{group}) {
+                        # and research recursively
+                        $ret = _getGroupInStructure($e->{group},$gn);
+                        return $ret if defined $ret;
+                }
+
+                # if we run into a component we need to check that out too
+                if (defined $e->{component}) {
+                        $ret = _getGroupInStructure(getComponentFields($e->{name}), $gn);
+                        return $ret if defined $ret;
+                }
+        }
+        undef;
+}
+
+
 sub getFieldName($) {
     my $f = shift;
     my $fh = getField($f);
@@ -369,14 +498,92 @@ sub getComponentFields($) {
 sub parseFixMessage {
     my $message = shift;
     my $nodes;
+
     for my $node ( split /\x01/, $message ) { # Split on "SOH"
         my @kvp = split /=/, $node; 
         if (scalar @kvp == 2) {
+	    my $isGrp = isGroup($kvp[0]);
+	    if ( $isGrp==1 ) {
+		my $fn = getFieldName($kvp[0]);
+	    	print "FieldName: $fn  IsGroup: $isGrp Value: $kvp[1]\n";
+	    }
             $nodes->{$kvp[0]}=$kvp[1];
             $nodes->{getFieldName($kvp[0])}=$kvp[1];
         }
     }
     return $nodes;
+}
+
+##Add fromString and  _parseFixArray
+sub fromString($) {
+        #my ( $self, $s ) = @_;
+	my $s = shift;
+
+        return if !defined $s;
+        my %arr;
+        my @fields = split( "\001", $s );
+        my $n = scalar(@fields) - 1;
+
+	print "Inside fromString $s \n";
+
+        _parseFixArray( \%arr, undef, undef, 0, \@fields );
+
+       # $self->{_AMSG} = \%arr;
+       # $self->{_SMSG} = $s;
+	return %arr;
+}
+
+sub _parseFixArray($$$$$) {
+        my ( $arr, $msgType, $gName, $iField, $fields ) = @_;
+        #my $fixDico = $self->{_dd};
+        my $n       = scalar(@$fields);
+        my $i       = $iField;
+
+	print "$n $i ###\n";
+
+        while ( $i < $n ) {
+                my $field = $fields->[$i];
+                my ( $k, $v ) = ( $field =~ /^([^=]+)=(.*)$/ );
+
+		print "Field: $field\n";
+
+                if ( defined $arr->{$k} ) {
+                        return $i if defined $gName;
+                        warn("Field $k is already in hash!");
+                }
+                if ( defined $gName ) {
+                        return $i if !isFieldInGroup( $msgType, $gName, $k );
+                }
+		#Store both using Tag and FieldName.
+                $arr->{$k} = $v;
+		$arr->{getFieldName($k)} = $v;
+                if ( $k == 8 ) {
+                        #do nothing
+                }
+                elsif ( $k == 35 ) {
+                        $msgType = $v;
+                }
+                else {
+                        my $fieldName = getFieldName($k);
+                        if ( !defined $fieldName ) {
+                                warn("Did not find field $k in dictionary");
+                        }
+                        elsif ( isGroup($k) ) {
+                                my @elems;
+                                ++$i;
+                                for my $j ( 1 .. $v ) {
+                                        my %newArr;
+                                        $i = _parseFixArray( \%newArr, $msgType, $k, $i, $fields );
+                                        push( @elems, \%newArr );
+                                }
+				#Store both using Tag and FieldName.
+                                $arr->{$k} = \@elems;
+				$arr->{$fieldName} = \@elems;
+                                --$i;
+                        }
+                }
+                ++$i;
+	}
 }
 
 sub randomString {

--- a/lib/FIX/Lite.pm
+++ b/lib/FIX/Lite.pm
@@ -2,7 +2,7 @@ package FIX::Lite;
 
 use vars qw($VERSION @ISA);
 use warnings;
-#use strict;
+use strict;
 
 use IO::Socket;
 use POSIX qw(strftime);


### PR DESCRIPTION
Hi Vitaly,

I made two small changes to your codes.
1. Handling of Multiple FIX messages within one single TCPIP message.

Example: 

---

Received FIX message:
## 8=FIX.4.4|9=112|35=W|34=60|49=FixServer|52=20151216-07:38:59.438|56=CLIENT1|55=CADCHF|268=2|269=0|270=0.71849|269=1|270=0.71861|10=233|8=FIX.4.4|9=112|35=W|34=61|49=FixServer|52=20151216-07:38:59.438|56=CLIENT1|55=NZDUSD|268=2|269=0|270=0.67527|269=1|270=0.67535|10=042|

In this sample TCP/IP message I received from feed provider, it contains two FIX messages for Market Data. What I did was I split this into each single FIX message before parsing them.
1. Handling of Grouped Information.

In the sample message above, the grouped info is the Tag 268(NoMDEntries). 

268=2|269=0|270=0.67527|269=1|270=0.67535

It contains a repeated tags of 269 and 270 which stands for MDEntryType and MDEntryPx.

Here is a simple example of handler on how to traverse the grouped information:

---

  sub handler {
     my %resp = @_;

```
 while ( my ( $k, $v ) = each(%resp) ) {
    print "Key: ".$k." \n";
    if ( ref($v) eq 'ARRAY' ) {
            print "Value is an array\n";
            for my $g (@$v) {
                    print "ArrayValue1 : ".$g->{MDEntryType}."\n";
                    print "ArrayValue2 : ".$g->{MDEntryPx}."\n";
            }
    } else {
                    print "Value: ".$v."\n";
    }

 }

 return 1;
```

  }

---

Thanks,
Shahrizal
